### PR TITLE
Prevents partials from being turned into routes

### DIFF
--- a/lib/rails-brochure/home_content.rb
+++ b/lib/rails-brochure/home_content.rb
@@ -19,7 +19,7 @@ module Rails
       def self.file_names
         files = Dir.glob("#{home_folder_path}**/*.{#{Mime::EXTENSION_LOOKUP.keys.join(",")}}.*")
         #puts files.inspect
-        files.delete_if { |f| f.end_with?(".orig") || f.start_with("_") }
+        files.delete_if { |f| f.end_with?(".orig") || f.start_with?("_") }
         files
       end
 

--- a/lib/rails-brochure/home_content.rb
+++ b/lib/rails-brochure/home_content.rb
@@ -19,7 +19,7 @@ module Rails
       def self.file_names
         files = Dir.glob("#{home_folder_path}**/*.{#{Mime::EXTENSION_LOOKUP.keys.join(",")}}.*")
         #puts files.inspect
-        files.delete_if { |f| f.end_with?(".orig") }
+        files.delete_if { |f| f.end_with?(".orig") || f.start_with("_") }
         files
       end
 


### PR DESCRIPTION
This pull request removes partials from `HomeContent#file_names` to prevent them from being turned into publicly accessible routes unintentionally